### PR TITLE
Remove the ss58 2114 registration of Turing Network

### DIFF
--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -983,15 +983,6 @@
       "website": "https://chainflip.io/"
     },
     {
-      "prefix": 2114,
-      "network": "Turing",
-      "displayName": "Turing Network",
-      "symbols": ["TUR"],
-      "decimals": [10],
-      "standardAccount": "*25519",
-      "website": "https://oak.tech/turing/home/"
-    },
-    {
       "prefix": 2207,
       "network": "SNOW",
       "displayName": "SNOW: ICE Canary Network",


### PR DESCRIPTION
The 2114 ss58 we saw was wrong. 
So we remove it.